### PR TITLE
Explicitly supply the model source

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ to see if your target browsers are compatible.
 $ ember install ember-sortable
 ```
 
-## Usage
-
+## Basic usage:
 ```js
 // app/routes/my-route.js
 
@@ -53,6 +52,30 @@ export default Ember.Route.extend({
 {{! app/templates/my-route.hbs }}
 
 {{#sortable-group tagName="ul" onChange="reorderItems" as |group|}}
+  {{#each model.items as |item|}}
+    {{#sortable-item tagName="li" model=item group=group handle=".handle"}}
+      {{item.name}}
+      <span class="handle">&varr;</span>
+    {{/sortable-item}}
+  {{/each}}
+{{/sortable-group}}
+```
+
+When `model` is set on the `sortable-group`, the `onChange` action is sent with two arguments: `groupModel` and `itemModels`:
+```js
+// app/routes/my-route.js
+  actions: {
+    reorderItems(groupModel, itemModels) {
+      groupModel.set('items', itemModels);
+    }
+  }
+});
+```
+
+```hbs
+{{! app/templates/my-route.hbs }}
+
+{{#sortable-group tagName="ul" model=model onChange="reorderItems" as |group|}}
   {{#each model.items as |item|}}
     {{#sortable-item tagName="li" model=item group=group handle=".handle"}}
       {{item.name}}

--- a/addon/components/sortable-group.js
+++ b/addon/components/sortable-group.js
@@ -94,7 +94,8 @@ export default Component.extend({
   */
   commit() {
     let items = this.get('sortedItems');
-    let models = items.mapBy('model');
+    let groupModel = this.get('model');
+    let itemModels = items.mapBy('model');
 
     delete this._itemPosition;
 
@@ -111,7 +112,11 @@ export default Component.extend({
         items.invoke('thaw');
       });
     });
-
-    this.sendAction('onChange', models);
+    
+    if  (groupModel === null || groupModel === undefined) {
+      this.sendAction('onChange', itemModels);
+    } else {
+      this.sendAction('onChange', groupModel, itemModels);
+    }
   }
 });

--- a/addon/components/sortable-group.js
+++ b/addon/components/sortable-group.js
@@ -2,16 +2,23 @@ import Ember from 'ember';
 import layout from '../templates/components/sortable-group';
 const { $, A, Component, computed, get, set, run } = Ember;
 const a = A;
+const NO_MODEL = {};
 
 export default Component.extend({
   layout: layout,
+
+  /**
+    @property model
+    @type Any
+    @default null
+  */
+  model: NO_MODEL,
 
   /**
     @property items
     @type Ember.NativeArray
   */
   items: computed(() => { return a(); }),
-
   /**
     Vertical position for the first item.
 
@@ -113,10 +120,10 @@ export default Component.extend({
       });
     });
     
-    if  (groupModel === null || groupModel === undefined) {
-      this.sendAction('onChange', itemModels);
-    } else {
+    if (groupModel !== NO_MODEL) {
       this.sendAction('onChange', groupModel, itemModels);
+    } else {
+      this.sendAction('onChange', itemModels);
     }
   }
 });

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -10,8 +10,8 @@ export default Ember.Route.extend({
   },
 
   actions: {
-    update(newOrder) {
-      this.set('currentModel.items', a(newOrder));
+    update(model, newOrder) {
+      a(model).set('items', a(newOrder));
     }
   }
 });

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-const { A } = Ember;
+const { A, set } = Ember;
 const a = A;
 
 export default Ember.Route.extend({
@@ -11,7 +11,7 @@ export default Ember.Route.extend({
 
   actions: {
     update(model, newOrder) {
-      a(model).set('items', a(newOrder));
+      set(model,'items', a(newOrder));
     }
   }
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -3,7 +3,7 @@
 </header>
 
 <main>
-  {{#sortable-group tagName="ol" onChange="update" as |group|}}
+  {{#sortable-group tagName="ol" model=model onChange="update" as |group|}}
     {{#each model.items as |item|}}
       {{#sortable-item tagName="li" model=item group=group handle=".handle"}}
         {{item}}

--- a/tests/unit/components/sortable-group-test.js
+++ b/tests/unit/components/sortable-group-test.js
@@ -166,3 +166,37 @@ test('commit with specified group model', function(assert) {
   assert.deepEqual(targetObject.newModel.newOrder, ['foo', 'bar', 'baz'],
     'expected target to receive models in order');
 });
+
+test('commit with missmatched group model', function(assert) {
+  let items = [{
+    y: 20,
+    model: 'bar'
+  }, {
+    y: 30,
+    model: 'baz'
+  }, {
+    y: 10,
+    model: 'foo'
+  }];
+  let model = null;
+  let targetObject = Ember.Object.create({
+    reorder(model, newOrder) {
+      if (typeof newOrder !== 'undefined') {
+        targetObject.correctActionFired = true;
+      }
+    }
+  });
+  let component = this.subject({
+    model,
+    items,
+    targetObject,
+    onChange: 'reorder'
+  });
+
+  run(() => {
+    component.commit();
+  });
+
+  assert.equal(targetObject.correctActionFired, true,
+    'expected reorder() to receive two params');
+});

--- a/tests/unit/components/sortable-group-test.js
+++ b/tests/unit/components/sortable-group-test.js
@@ -100,7 +100,7 @@ test('update', function(assert) {
     'expected y positions to be applied to all but isDragging');
 });
 
-test('commit', function(assert) {
+test('commit without specified group model', function(assert) {
   let items = [{
     y: 20,
     model: 'bar'
@@ -111,6 +111,7 @@ test('commit', function(assert) {
     y: 10,
     model: 'foo'
   }];
+
   let targetObject = Ember.Object.create({
     reorder(newOrder) {
       this.newOrder = newOrder;
@@ -127,5 +128,41 @@ test('commit', function(assert) {
   });
 
   assert.deepEqual(targetObject.newOrder, ['foo', 'bar', 'baz'],
+    'expected target to receive models in order');
+});
+
+test('commit with specified group model', function(assert) {
+  let items = [{
+    y: 20,
+    model: 'bar'
+  }, {
+    y: 30,
+    model: 'baz'
+  }, {
+    y: 10,
+    model: 'foo'
+  }];
+
+  let model = {
+    items: items
+  };
+  let targetObject = Ember.Object.create({
+    reorder(model, newOrder) {
+      model.newOrder = newOrder;
+      targetObject.newModel = model;
+    }
+  });
+  let component = this.subject({
+    model,
+    items,
+    targetObject,
+    onChange: 'reorder'
+  });
+
+  run(() => {
+    component.commit();
+  });
+
+  assert.deepEqual(targetObject.newModel.newOrder, ['foo', 'bar', 'baz'],
     'expected target to receive models in order');
 });

--- a/tests/unit/mixins/sortable-item-test.js
+++ b/tests/unit/mixins/sortable-item-test.js
@@ -103,8 +103,9 @@ test('registers itself with group', function(assert) {
 });
 
 test('deregisters itself when removed', function(assert) {
-  subject.remove();
-
+  run(() => {
+    subject.remove();
+  });
   assert.equal(group.item, undefined,
     'expected to be deregistered with group');
 });


### PR DESCRIPTION
So that `reorderItems` action handler knows which model it is modifying.
Updated code examples in README.

per #22 