### PR TITLE
Add Ember Addon 'demoURL'

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "ember-cli-htmlbars": "0.7.4"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "demoURL": "http://jgwhite.co.uk/ember-sortable/demo/"
   }
 }


### PR DESCRIPTION
Ember addons can now provide a demoURL which provides users with a demo link on ember observer.com and emberaddons.com.

See example from [ember-modal-dialog](https://github.com/yapplabs/ember-modal-dialog) (implemented in [this commit](https://github.com/yapplabs/ember-modal-dialog/commit/83ce265b9159ba3270ced967e55a82a64d154cd8)):

* [emberaddons.com](http://www.emberaddons.com/?query=ember-modal-dialog)
* [emberobserver.com](http://emberobserver.com/addons/ember-modal-dialog)

You probably need to publish a new version to npm - I'll leave that up to you (: