### PR TITLE
New Computed Syntax

### DIFF
--- a/addon/components/sortable-group.js
+++ b/addon/components/sortable-group.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import layout from '../templates/components/sortable-group';
-const { $, A, Component, computed, get, set, run } = Ember;
+import computed from 'ember-new-computed';
+const { $, A, Component, get, set, run } = Ember;
 const a = A;
 const NO_MODEL = {};
 
@@ -18,29 +19,35 @@ export default Component.extend({
     @property items
     @type Ember.NativeArray
   */
-  items: computed(() => { return a(); }),
+  items: computed({
+    get() { return a(); }
+  }),
   /**
     Vertical position for the first item.
 
     @property itemPosition
     @type Number
   */
-  itemPosition: computed(function() {
-    let element = this.element;
-    let stooge = $('<span style="position: absolute" />');
-    let result = stooge.prependTo(element).position().top;
+  itemPosition: computed({
+    get() {
+      let element = this.element;
+      let stooge = $('<span style="position: absolute" />');
+      let result = stooge.prependTo(element).position().top;
 
-    stooge.remove();
+      stooge.remove();
 
-    return result;
+      return result;
+    }
   }).volatile(),
 
   /**
     @property sortedItems
     @type Array
   */
-  sortedItems: computed('items.@each.y', function() {
-    return a(this.get('items')).sortBy('y');
+  sortedItems: computed('items.@each.y', {
+    get() {
+      return a(this.get('items')).sortBy('y');
+    }
   }),
 
   /**
@@ -119,7 +126,7 @@ export default Component.extend({
         items.invoke('thaw');
       });
     });
-    
+
     if (groupModel !== NO_MODEL) {
       this.sendAction('onChange', groupModel, itemModels);
     } else {

--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
-const { Mixin, $, computed, run } = Ember;
+import computed from 'ember-new-computed';
+const { Mixin, $, run } = Ember;
 const { Promise } = Ember.RSVP;
 
 export default Mixin.create({
@@ -56,7 +57,7 @@ export default Mixin.create({
     @property isBusy
     @type Boolean
   */
-  isBusy: computed.or('isDragging', 'isDropping'),
+  isBusy: Ember.computed.or('isDragging', 'isDropping'),
 
   /**
     The frequency with which the group is informed
@@ -74,11 +75,13 @@ export default Mixin.create({
     @property isAnimated
     @type Boolean
   */
-  isAnimated: computed(function() {
-    let el = this.$();
-    let property = el.css('transition-property');
+  isAnimated: computed({
+    get() {
+      let el = this.$();
+      let property = el.css('transition-property');
 
-    return /all|transform/.test(property);
+      return /all|transform/.test(property);
+    }
   }).volatile(),
 
   /**
@@ -87,23 +90,25 @@ export default Mixin.create({
     @property transitionDuration
     @type Number
   */
-  transitionDuration: computed(function() {
-    let el = this.$();
-    let rule = el.css('transition-duration');
-    let match = rule.match(/([\d\.]+)([ms]*)/);
+  transitionDuration: computed({
+    get() {
+      let el = this.$();
+      let rule = el.css('transition-duration');
+      let match = rule.match(/([\d\.]+)([ms]*)/);
 
-    if (match) {
-      let value = parseFloat(match[1]);
-      let unit = match[2];
+      if (match) {
+        let value = parseFloat(match[1]);
+        let unit = match[2];
 
-      if (unit === 's') {
-        value = value * 1000;
+        if (unit === 's') {
+          value = value * 1000;
+        }
+
+        return value;
       }
 
-      return value;
+      return 0;
     }
-
-    return 0;
   }).volatile(),
 
   /**
@@ -112,17 +117,20 @@ export default Mixin.create({
     @property y
     @type Number
   */
-  y: computed(function(_, value) {
-    if (arguments.length === 2 && value !== this._y) {
+  y: computed({
+    get() {
+      if (this._y === undefined) {
+        this._y = this.element.offsetTop;
+      }
+
+      return this._y;
+    },
+    set(key, value) {
       this._y = value;
       this._scheduleApplyPosition();
-    }
 
-    if (this._y === undefined) {
-      this._y = this.element.offsetTop;
+      return this._y;
     }
-
-    return this._y;
   }).volatile(),
 
   /**
@@ -131,10 +139,12 @@ export default Mixin.create({
     @property height
     @type Number
   */
-  height: computed(function() {
-    let height = this.$().outerHeight();
-    let marginBottom = parseFloat(this.$().css('margin-bottom'));
-    return height + marginBottom;
+  height: computed({
+    get() {
+      let height = this.$().outerHeight();
+      let marginBottom = parseFloat(this.$().css('margin-bottom'));
+      return height + marginBottom;
+    }
   }).volatile(),
 
   /**

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "ember-data": "1.0.0-beta.16.1",
     "ember-export-application-global": "^1.0.2",
     "ember-disable-prototype-extensions": "^1.0.0",
+    "ember-new-computed": "1.0.0",
     "ember-try": "0.0.4"
   },
   "keywords": [


### PR DESCRIPTION
This is to implement the new computed property syntax to removes deprecation warning from Ember 1.13.

If you are Ok with only supporting Ember v1.12.0-beta.1+ then the use of a plugin can be removed - let me know if you would prefer to go that way and I'll update the PR.