### PR TITLE
Pass dragged model to onChange callback

### DIFF
--- a/addon/components/sortable-group.js
+++ b/addon/components/sortable-group.js
@@ -110,6 +110,9 @@ export default Component.extend({
     let items = this.get('sortedItems');
     let groupModel = this.get('model');
     let itemModels = items.mapBy('model');
+    let draggedItem = items.filter(i => get(i, 'wasDropped'))[0]
+    draggedItem.set('wasDropped', false) // Reset
+    let draggedModel = draggedItem.get('model')
 
     delete this._itemPosition;
 
@@ -128,9 +131,9 @@ export default Component.extend({
     });
 
     if (groupModel !== NO_MODEL) {
-      this.sendAction('onChange', groupModel, itemModels);
+      this.sendAction('onChange', groupModel, itemModels, draggedModel);
     } else {
-      this.sendAction('onChange', itemModels);
+      this.sendAction('onChange', itemModels, draggedModel);
     }
   }
 });

--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -54,6 +54,16 @@ export default Mixin.create({
   isDropping: false,
 
   /**
+  True if the item was dropped during the interaction
+
+  @property wasDropped
+  @type Boolean
+  @default false
+  */
+  wasDropped: false,
+
+
+  /**
     @property isBusy
     @type Boolean
   */
@@ -337,6 +347,7 @@ export default Mixin.create({
   */
   _complete() {
     this.set('isDropping', false);
+    this.set('wasDropped', true);
     this._tellGroup('commit');
   }
 });


### PR DESCRIPTION
I'm really enjoying the add-on, but I need to know which element was moved. This pull requests adds support for that. 