### PR TITLE
Use `closest` vs `is` to support complex handles (e.g. SVG)

### DIFF
--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -214,7 +214,7 @@ export default Mixin.create({
   _startDrag(event) {
     let handle = this.get('handle');
 
-    if (handle && !$(event.target).is(handle)) {
+    if (handle && !$(event.target).closest(handle).length) {
       return;
     }
 

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -7,7 +7,9 @@
     {{#each model.items as |item|}}
       {{#sortable-item tagName="li" model=item group=group handle=".handle"}}
         {{item}}
-        <span class="handle">&vArr;</span>
+        <span class="handle">
+          <span>&vArr;</span>
+        </span>
       {{/sortable-item}}
     {{/each}}
   {{/sortable-group}}


### PR DESCRIPTION
Ran into this because we're using SVGs for our icons & it didn't recognise that the handle was being dragged. This uses `closest` instead just to check that we're dragging something which is either the handle, or inside the handle.

Couldn't see any existing tests for handles, but added an inner span to the dummy app as this triggers the problem.