### PR TITLE
Add actions for `onDragStart` and `onDragStop`

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,37 @@ slightly different colour:
 }
 ```
 
+# Drag Actions
+
+The `onDragStart` and `onDragStop` actions are available for the
+`sortable-item`s. You can provide an action name to listen to these actions to
+be notified when an item is being dragged or not.
+
+When the action is called, the item's model will be provided as the only
+argument.
+
+```js
+// app/routes/my-route.js
+
+export default Ember.Route.extend({
+  actions: {
+    dragStarted(item) {
+      console.log(`Item started dragging: ${item.get('name')`);
+    },
+    dragStopped(item) {
+      console.log(`Item stopped dragging: ${item.get('name')`);
+    }
+  }
+});
+```
+
+```hbs
+  {{#sortable-item onDragStart="dragStarted" onDragStop="dragStopped" tagName="li" model=item group=group handle=".handle"}}
+    {{item.name}}
+    <span class="handle">&varr;</span>
+  {{/sortable-item}}
+```
+
 ### Data down, actions up
 
 No data is mutated by `sortable-group` or `sortable-item`. In the spirit of “data down, actions up”, a fresh array containing the models from each item in their new order is sent via the group’s `onChange` action.

--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -41,6 +41,22 @@ export default Mixin.create({
   isDragging: false,
 
   /**
+    Action that fires when the item starts being dragged.
+    @property onDragStart
+    @type Action
+    @default null
+  */
+  onDragStart: null,
+
+  /**
+    Action that fires when the item stops being dragged.
+    @property onDragStop
+    @type Action
+    @default null
+  */
+  onDragStop: null,
+
+  /**
     True if the item is currently dropping.
     @property isDropping
     @type Boolean
@@ -296,6 +312,7 @@ export default Mixin.create({
 
     this._tellGroup('prepare');
     this.set('isDragging', true);
+    this.sendAction('onDragStart', this.get('model'));
   },
 
   /**
@@ -449,6 +466,7 @@ export default Mixin.create({
     @private
   */
   _complete() {
+    this.sendAction('onDragStop', this.get('model'));
     this.set('isDropping', false);
     this.set('wasDropped', true);
     this._tellGroup('commit');

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -10,7 +10,6 @@ export default Ember.Route.extend({
 
   actions: {
     update(newOrder, draggedModel) {
-      console.log('Updated');
       this.set('currentModel.items', a(newOrder));
       this.set('currentModel.dragged', draggedModel);
     }

--- a/tests/unit/mixins/sortable-item-test.js
+++ b/tests/unit/mixins/sortable-item-test.js
@@ -3,6 +3,8 @@ import SortableItemMixin from 'ember-sortable/mixins/sortable-item';
 import { module, test } from 'qunit';
 const { Component, run } = Ember;
 
+const MockEvent = { originalEvent: null };
+const MockModel = { name: 'Mock Model' };
 const MockComponent = Component.extend(SortableItemMixin);
 const MockGroup = Ember.Object.extend({
   direction: 'y',
@@ -14,9 +16,9 @@ const MockGroup = Ember.Object.extend({
     delete this.item;
   },
 
+  commit() {},
+  prepare() {},
   update() {},
-
-  commit() {}
 });
 
 let group;
@@ -140,6 +142,40 @@ test('deregisters itself when removed', function(assert) {
   });
   assert.equal(group.item, undefined,
     'expected to be deregistered with group');
+});
+
+test('dragStart fires an action if provided', function(assert) {
+  assert.expect(1);
+
+  const targetObject = {
+    action(passedModel) {
+      assert.equal(passedModel, MockModel);
+    }
+  };
+
+  run(() => {
+    subject.set('model', MockModel);
+    subject.set('targetObject', targetObject);
+    subject.set('onDragStart', 'action');
+    subject._startDrag(MockEvent);
+  });
+});
+
+test('dragStop fires an action if provided', function(assert) {
+  assert.expect(1);
+
+  const targetObject = {
+    action(passedModel) {
+      assert.equal(passedModel, MockModel);
+    }
+  };
+
+  run(() => {
+    subject.set('model', MockModel);
+    subject.set('targetObject', targetObject);
+    subject.set('onDragStop', 'action');
+    subject._complete();
+  });
 });
 
 function getTransform(element) {


### PR DESCRIPTION
I had the need to change a property in my parent template when something was dragging vs when it wasn't. Following the "Data Down, Actions Up", this seemed like the cleanest implementation.

I don't care for testing private methods but I didn't think it warranted a full on event and such for just testing these actions.

I also removed a `console.log` that didn't seem to add any benefits. If there was a reason for that, just let me know.

Happy to take feedback.