### PR TITLE
Fix typos in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,10 @@ argument.
 export default Ember.Route.extend({
   actions: {
     dragStarted(item) {
-      console.log(`Item started dragging: ${item.get('name')`);
+      console.log(`Item started dragging: ${item.get('name')}`);
     },
     dragStopped(item) {
-      console.log(`Item stopped dragging: ${item.get('name')`);
+      console.log(`Item stopped dragging: ${item.get('name')}`);
     }
   }
 });


### PR DESCRIPTION
Adds two missing closing brackets to one of the examples in the README.