### PR TITLE
Expose `drag` and `reorder` test helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,24 @@ No data is mutated by `sortable-group` or `sortable-item`. In the spirit of “d
 
 Each item takes a `model` property. This should be fairly self-explanatory but it’s important to note that it doesn’t do anything with this object besides keeping a reference for later use in `onChange`.
 
+## Testing
+
+`ember-sortable` exposes some acceptance test helpers:
+
+* [`drag`][drag]: Drags elements by an offset specified in pixels.
+* [`reorder`][reorder]: Reorders elements to the specified state.
+
+[drag]: addon/helpers/drag.js
+[reorder]: addon/helpers/reorder.js
+
+To include them in your application, import then in your `test-helper.js`:
+
+```js
+// tests/test-helper.js
+
+import './ember-sortable/test-helpers';
+```
+
 ## Developing
 
 ### Setup

--- a/addon/helpers/drag.js
+++ b/addon/helpers/drag.js
@@ -25,8 +25,15 @@ import Ember from 'ember';
   @return {Promise}
 */
 
-export function drag(_app, mode, itemSelector, offsetFn, callbacks = {}) {
+export function drag(app, mode, itemSelector, offsetFn, callbacks = {}) {
   let start, move, end, which;
+
+  const {
+    andThen,
+    findWithAssert,
+    triggerEvent,
+    wait
+  } = app.testHelpers;
 
   if (mode === 'mouse') {
     start = 'mousedown';

--- a/addon/helpers/reorder.js
+++ b/addon/helpers/reorder.js
@@ -30,7 +30,14 @@ const OVERSHOOT = 2;
   @return {Promise}
 */
 
-export function reorder(_app, mode, itemSelector, ...resultSelectors) {
+export function reorder(app, mode, itemSelector, ...resultSelectors) {
+  const {
+    andThen,
+    drag,
+    findWithAssert,
+    wait
+  } = app.testHelpers;
+
   resultSelectors.forEach((selector, targetIndex) => {
     andThen(() => {
       let items = findWithAssert(itemSelector);

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "ember-cli-test-loader": "0.2.1",
     "ember-load-initializers": "0.1.7",
     "ember-qunit-notifications": "0.1.0",
-    "jquery": "^1.11.3",
+    "jquery": "~1.11.3",
     "loader.js": "^3.5.0",
     "qunit": "~1.20.0"
   },

--- a/test-support/helpers/ember-sortable/test-helpers.js
+++ b/test-support/helpers/ember-sortable/test-helpers.js
@@ -1,0 +1,2 @@
+import 'ember-sortable/helpers/drag';
+import 'ember-sortable/helpers/reorder';

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,6 +1,6 @@
 import resolver from './helpers/resolver';
 import { setResolver } from 'ember-qunit';
-import reorder from './helpers/reorder'; // jshint ignore:line
-import drag from './helpers/drag'; // jshint ignore:line
+import 'ember-sortable/helpers/drag';
+import 'ember-sortable/helpers/reorder';
 
 setResolver(resolver);


### PR DESCRIPTION
Drag-and-drop interactions are very difficult to test. Consumers of this
addon would like to test their application's interactions with the
addon.

Exposing `drag` and `reorder` gives consumers the tools to verify that
they're interacting with the addon properly.