### PR TITLE
A new sortable-item property: spacing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /libpeerconnection.log
 npm-debug.log
 testem.log
+.idea

--- a/README.md
+++ b/README.md
@@ -94,6 +94,19 @@ To change sort direction, define `direction` on `sortable-group` (default is `y`
 {{#sortable-group direction="x" onChange="reorderItems" as |group|}}
 ```
 
+### Changing spacing between currently dragged element and the rest of the group
+
+When user starts to drag element, other elements jump back. Works both for the `x` and `y` direction option.
+
+In `y` case: elements above current one jump up, and elements below current one - jump down.
+In `x` case: elements before current one jump to the left, and elements after current one - jump to the right.
+
+To change this property, define `spacing` on `sortable-item` (default is `0`):
+
+```hbs
+{{#sortable-item tagName="li" group=group spacing=15}}
+```
+
 ### CSS, Animation
 
 Sortable items can be in one of three states: default, dragging, dropping.

--- a/addon/components/sortable-group.js
+++ b/addon/components/sortable-group.js
@@ -30,12 +30,14 @@ export default Component.extend({
 
   /**
     Position for the first item.
+    If spacing is present, first item's position will have to change as well.
     @property itemPosition
     @type Number
   */
   itemPosition: computed(function() {
     let direction = this.get('direction');
-    return this.get(`sortedItems.firstObject.${direction}`);
+
+    return this.get(`sortedItems.firstObject.${direction}`) - this.get('sortedItems.firstObject.spacing');
   }).volatile(),
 
   /**
@@ -78,11 +80,12 @@ export default Component.extend({
   },
 
   /**
-    Update item positions.
+    Update item positions (relatively to the first element position).
     @method update
   */
   update() {
     let sortedItems = this.get('sortedItems');
+    // Position of the first element
     let position = this._itemPosition;
 
     // Just in case we haven’t called prepare first.
@@ -96,6 +99,11 @@ export default Component.extend({
 
       if (!get(item, 'isDragging')) {
         set(item, direction, position);
+      }
+
+      // add additional spacing around active element
+      if (get(item, 'isBusy')) {
+        position += get(item, 'spacing') * 2;
       }
 
       if (direction === 'x') {

--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -89,6 +89,14 @@ export default Mixin.create({
   updateInterval: 125,
 
   /**
+    Additional spacing between active item and the rest of the elements.
+    @property spacing
+    @type Number
+    @default 0[px]
+  */
+  spacing: 0,
+
+  /**
     True if the item transitions with animation.
     @property isAnimated
     @type Boolean

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -67,6 +67,19 @@
   color: pink;
 }
 
+.vertical-spacing-demo .sortable-item {
+  display: block;
+  position: relative;
+  background: #58D3F7;
+  width: 50%;
+  line-height: 50px;
+  margin: 5px auto;
+  text-align: center;
+}
+
+.vertical-spacing-demo .sortable-item.is-dragging {
+  background: #A9E2F3;
+}
 
 .horizontal-demo .sortable-item {
   display: inline-block;

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -53,6 +53,20 @@
       </table>
     </section>
 
+    <section class="vertical-spacing-demo">
+      <h3>Vertical with 15px spacing</h3>
+
+      {{#sortable-group tagName="ol" onChange="update" as |group|}}
+        {{#each model.items as |item|}}
+          {{#sortable-item tagName="li" model=item group=group spacing=15}}
+            {{item}}
+            <span class="handle" data-item="{{item}}">
+            </span>
+          {{/sortable-item}}
+        {{/each}}
+      {{/sortable-group}}
+    </section>
+
     <section class="scrollable-demo">
       <h3>Scrollable</h3>
 

--- a/tests/unit/components/sortable-group-test.js
+++ b/tests/unit/components/sortable-group-test.js
@@ -41,13 +41,16 @@ test('[de]registerItem', function(assert) {
 test('update', function(assert) {
   let items = [{
     y: 10,
-    height: 15
+    height: 15,
+    spacing: 0
   }, {
     y: 20,
-    height: 10
+    height: 10,
+    spacing: 0
   }, {
     y: 5,
     height: 20,
+    spacing: 0,
     isDragging: true
   }];
   let component = this.subject({ items });
@@ -58,18 +61,172 @@ test('update', function(assert) {
 
   let expected = [{
     y: 25,
-    height: 15
+    height: 15,
+    spacing: 0
   }, {
     y: 40,
-    height: 10
+    height: 10,
+    spacing: 0
   }, {
     y: 5,
     height: 20,
+    spacing: 0,
     isDragging: true
   }];
 
+
   assert.deepEqual(items, expected,
     'expected y positions to be applied to all but isDragging');
+});
+
+test('update', function(assert) {
+  let items = [{
+    y: 15,
+    height: 15,
+    spacing: 10
+  }, {
+    y: 20,
+    height: 10,
+    spacing: 10
+  }, {
+    y: 35,
+    height: 25,
+    spacing: 10,
+    isDragging: true
+  }, {
+    y: 45,
+    height: 20,
+    spacing: 10
+  }];
+
+  let component = this.subject({ items });
+
+  this.render();
+
+  component.update();
+
+  let expected = [{
+    y: 5,
+    height: 15,
+    spacing: 10
+  }, {
+    y: 20,
+    height: 10,
+    spacing: 10
+  }, {
+    y: 35,
+    height: 25,
+    spacing: 10,
+    isDragging: true
+  }, {
+    y: 55,
+    height: 20,
+    spacing: 10,
+  }];
+
+  assert.deepEqual(items, expected,
+    'expected y positions to be applied to all but isDragging and with regard to defined spacing');
+});
+
+test('update', function(assert) {
+  let items = [{
+    y: 15,
+    height: 15,
+    spacing: 8
+  }, {
+    y: 20,
+    height: 10,
+    spacing: 9
+  }, {
+    y: 35,
+    height: 25,
+    spacing: 10,
+    isDragging: true
+  }, {
+    y: 45,
+    height: 20,
+    spacing: 11
+  }];
+
+  let component = this.subject({ items });
+
+  this.render();
+
+  component.update();
+
+  let expected = [{
+    y: 7,
+    height: 15,
+    spacing: 8
+  }, {
+    y: 22,
+    height: 10,
+    spacing: 9
+  }, {
+    y: 35,
+    height: 25,
+    spacing: 10,
+    isDragging: true
+  }, {
+    y: 57,
+    height: 20,
+    spacing: 11,
+  }];
+
+  assert.deepEqual(items, expected,
+    'expected y positions to be applied to all but isDragging and with regard to defined spacing - for each element different');
+});
+
+test('update', function(assert) {
+  let items = [{
+    x: 15,
+    width: 15,
+    spacing: 10
+  }, {
+    x: 20,
+    width: 10,
+    spacing: 10
+  }, {
+    x: 35,
+    width: 25,
+    spacing: 10,
+    isDragging: true
+  }, {
+    x: 45,
+    width: 20,
+    spacing: 10
+  }];
+
+  let component = this.subject({
+    items,
+    direction: 'x'
+  });
+
+  this.render();
+
+  component.update();
+
+  let expected = [{
+    x: 5,
+    width: 15,
+    spacing: 10
+  }, {
+    x: 20,
+    width: 10,
+    spacing: 10
+  }, {
+    x: 35,
+    width: 25,
+    spacing: 10,
+    isDragging: true
+  }, {
+    x: 55,
+    width: 20,
+    spacing: 10,
+  }];
+
+  assert.deepEqual(items, expected,
+    'expected x positions to be applied to all but isDragging and with regard to defined spacing');
 });
 
 test('commit without specified group model', function(assert) {


### PR DESCRIPTION
This PR introduces a new property to ember-sortable: the spacing which appears after dragging an element. When users starts to drag element, other elements jump back, which is a nice visual effect. It works both for the x and y option;
In `y` case elements above current one jump up, and elements below current one - jump down.
In `x` case elements before current one jump to the left, and elements after current one - jump to the right.
The `spacing` is defined for each item which uses the `sortable-item` mixin (and can be different for each of the elements).