### PR TITLE
Autoscroll while dragging sortable-items

### DIFF
--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -334,6 +334,13 @@ export default Mixin.create({
     this._scrollOnEdges(drag);
   },
 
+  /**
+    The maximum scroll speed when dragging element.
+    @property maxScrollSpeed
+    @default 20
+   */
+  maxScrollSpeed: 20,
+
   _scrollOnEdges(drag) {
     let groupDirection = this.get('group.direction');
     let $element = this.$();
@@ -382,8 +389,8 @@ export default Mixin.create({
       }
 
       if (delta !== 0) {
-        // clamp between -15px and 15px
-        delta = Math.min(Math.max(delta, -15), 15);
+        let speed = this.get('maxScrollSpeed');
+        delta = Math.min(Math.max(delta, -1 * speed), speed);
 
         scrollContainer[scrollKey](scroll + delta);
         if (this._event) {

--- a/addon/system/scroll-container.js
+++ b/addon/system/scroll-container.js
@@ -1,0 +1,68 @@
+import Ember from 'ember';
+const { $ } = Ember;
+
+export default class ScrollContainer {
+  constructor(element) {
+    this.element = element;
+    this.isWindow = element === document;
+    if (this.isWindow) {
+      this.top = this.scrollTop();
+      this.left = this.scrollLeft();
+      this.width = $(window).width();
+      this.height = $(window).height();
+      this.scrollWidth = this.$().width();
+      this.scrollHeight = this.$().height();
+    } else {
+      let { top, left } = this.$().offset();
+      this.top = top;
+      this.left = left;
+      this.width = this.$().width();
+      this.height = this.$().height();
+      this.scrollWidth = element.scrollWidth;
+      this.scrollHeight = element.scrollHeight;
+    }
+    this.maxScrollTop = this.scrollHeight - this.height;
+    this.maxScrollLeft = this.scrollWidth - this.width;
+  }
+
+  get bottom() {
+    return this.top + this.height;
+  }
+
+  get right() {
+    return this.left + this.width;
+  }
+
+  scrollTop(value) {
+    if (value) {
+      value = Math.max(0, Math.min(this.maxScrollTop, value));
+      this.$().scrollTop(value);
+      if (this.isWindow) {
+        this.top = value;
+      }
+      return value;
+    }
+    return this.$().scrollTop();
+  }
+
+  scrollLeft(value) {
+    if (value) {
+      value = Math.max(0, Math.min(this.maxScrollLeft, value));
+      this.$().scrollLeft(value);
+      if (this.isWindow) {
+        this.left = value;
+      }
+      return value;
+    }
+    return this.$().scrollLeft();
+  }
+
+  $(selector) {
+    let element = this.element;
+    if (selector) {
+      return $(element).find(selector);
+    } else {
+      return $(element);
+    }
+  }
+}

--- a/addon/system/scroll-parent.js
+++ b/addon/system/scroll-parent.js
@@ -1,0 +1,20 @@
+import Ember from 'ember';
+const { $ } = Ember;
+
+export default function ($element) {
+  let position = $element.css('position');
+  let excludeStaticParent = position === 'absolute';
+  let $scrollParent = $element.parents().filter(function () {
+    let $parent = $(this);
+    if (excludeStaticParent && $parent.css('position') === 'static') {
+      return false;
+    }
+    let { overflow, overflowX, overflowY } = $parent.css(['overflow', 'overflowX', 'overflowY']);
+    return /(auto|scroll)/.test(overflow + overflowX + overflowY);
+  }).eq(0);
+
+  if ($scrollParent.length === 0) {
+    $scrollParent = $(document);
+  }
+  return position === 'fixed' || $scrollParent;
+}

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -81,6 +81,11 @@
   background: #A9E2F3;
 }
 
+.horizontal-demo {
+  overflow: auto;
+  white-space: nowrap;
+}
+
 .horizontal-demo .sortable-item {
   display: inline-block;
   position: relative;


### PR DESCRIPTION
This builds in functionality to scroll the container when a `{{sortable-item}}` reaches the bounding edge of its parent scroll container.

Some more work is needed to get scrolling smooth when the browser window is the element that should scroll, but it works wonderfully in scrollable containers. To test, you can try dragging items to the edges of the browser window and the page should move :)