### PR TITLE
Fix test helpers in ember-cli-qunit 3.0

### DIFF
--- a/addon/helpers/drag.js
+++ b/addon/helpers/drag.js
@@ -52,8 +52,9 @@ export function drag(app, mode, itemSelector, offsetFn, callbacks = {}) {
     let item = findWithAssert(itemSelector);
     let itemOffset = item.offset();
     let offset = offsetFn();
-    let rect = item.get(0).getBoundingClientRect();
-    let scale = item.outerHeight() / (rect.bottom - rect.top);
+    let itemElement = item.get(0);
+    let rect = itemElement.getBoundingClientRect();
+    let scale = itemElement.clientHeight / (rect.bottom - rect.top);
     let targetX = itemOffset.left + offset.dx * scale;
     let targetY = itemOffset.top + offset.dy * scale;
 

--- a/addon/helpers/drag.js
+++ b/addon/helpers/drag.js
@@ -52,8 +52,10 @@ export function drag(app, mode, itemSelector, offsetFn, callbacks = {}) {
     let item = findWithAssert(itemSelector);
     let itemOffset = item.offset();
     let offset = offsetFn();
-    let targetX = itemOffset.left + offset.dx;
-    let targetY = itemOffset.top + offset.dy;
+    let rect = item.get(0).getBoundingClientRect();
+    let scale = item.outerHeight() / (rect.bottom - rect.top);
+    let targetX = itemOffset.left + offset.dx * scale;
+    let targetY = itemOffset.top + offset.dy * scale;
 
     triggerEvent(app, item, start, {
       pageX: itemOffset.left,

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -160,3 +160,7 @@
   background: rgba(127, 0, 0, .5);
   color: pink;
 }
+
+#ember-testing {
+  transform: none !important
+}

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -162,5 +162,5 @@
 }
 
 #ember-testing {
-  transform: none !important
+  transform: none !important;
 }

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -155,7 +155,3 @@
   background: rgba(127, 0, 0, .5);
   color: pink;
 }
-
-#ember-testing {
-  transform: none !important;
-}


### PR DESCRIPTION
This is a fix for #105. I've updated the `drag` helper to apply a scaling factor to `dx` and `dy`, which fixes the failing tests when running under `ember-cli-qunit` 3.0, and should remain compatible with 2.x as well.