### PR TITLE
Remove event listeners in willDestroyElement

### DIFF
--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -225,6 +225,10 @@ export default Mixin.create({
     // scheduled to prevent deprecation warning:
     // "never change properties on components, services or models during didInsertElement because it causes significant performance degradation"
     run.schedule("afterRender", this, "_tellGroup", "deregisterItem", this);
+
+    // remove event listeners that may still be attached
+    $(window).off('mousemove touchmove', this._startDragListener);
+    $(window).off('click mouseup touchend', this._cancelStartDragListener);
   },
 
   /**
@@ -294,14 +298,14 @@ export default Mixin.create({
     event.preventDefault();
     event.stopPropagation();
 
-    let startDragListener = event => this._startDrag(event);
+    this._startDragListener = event => this._startDrag(event);
 
-    function cancelStartDragListener() {
-      $(window).off('mousemove touchmove', startDragListener);
-    }
+    this._cancelStartDragListener = () => {
+      $(window).off('mousemove touchmove', this._startDragListener);
+    };
 
-    $(window).one('mousemove touchmove', startDragListener);
-    $(window).one('click mouseup touchend', cancelStartDragListener);
+    $(window).one('mousemove touchmove', this._startDragListener);
+    $(window).one('click mouseup touchend', this._cancelStartDragListener);
   },
 
   /**


### PR DESCRIPTION
`cancelStartDragListener` is retaining components in tests due to the event listener not always being torn down. When I was tracking down memory leaks in our application, we found that this method was one of the points in our test suite that would retain a bunch of memory (~9Mb or so) through our test run of 1,000 tests.

This fixes #110 