### PR TITLE
Use document as the scroll parent if the body is the scroll parent

### DIFF
--- a/addon/system/scroll-parent.js
+++ b/addon/system/scroll-parent.js
@@ -13,7 +13,8 @@ export default function ($element) {
     return /(auto|scroll)/.test(overflow + overflowX + overflowY);
   }).eq(0);
 
-  if ($scrollParent.length === 0) {
+  if ($scrollParent.length === 0 ||
+      $scrollParent[0] === document.body) {
     $scrollParent = $(document);
   }
   return position === 'fixed' || $scrollParent;


### PR DESCRIPTION
Fix #116 by using the document instead of the body element as the scroll parent.