### PR TITLE
adds support for 'data-test-selector' attribute

### DIFF
--- a/addon/components/sortable-group.js
+++ b/addon/components/sortable-group.js
@@ -10,6 +10,8 @@ const NO_MODEL = {};
 export default Component.extend({
   layout: layout,
 
+  attributeBindings: ['data-test-selector'],
+
   /**
     @property direction
     @type string

--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -11,6 +11,8 @@ export default Mixin.create({
   classNames: ['sortable-item'],
   classNameBindings: ['isDragging', 'isDropping'],
 
+  attributeBindings: ['data-test-selector'],
+
   /**
     Group to which the item belongs.
     @property group

--- a/tests/unit/components/sortable-group-test.js
+++ b/tests/unit/components/sortable-group-test.js
@@ -361,3 +361,10 @@ test('draggedModel', function(assert) {
     component.commit();
   });
 });
+
+test('renders data-test-selector', function(assert) {
+  let component = this.subject();
+
+  assert.ok(component.get('attributeBindings').indexOf('data-test-selector') > -1,
+  'support data-test-selector attribute binging');
+});

--- a/tests/unit/components/sortable-item-test.js
+++ b/tests/unit/components/sortable-item-test.js
@@ -20,3 +20,10 @@ test('it renders', function(assert) {
   this.render();
   assert.equal(component._state, 'inDOM');
 });
+
+test('renders data-test-selector', function(assert) {
+  let component = this.subject();
+
+  assert.ok(component.get('attributeBindings').indexOf('data-test-selector') > -1,
+    'support data-test-selector attribute binding');
+});


### PR DESCRIPTION
Adds (optional) attribute bindings for `data-test-selector` to the `sortable-group` and `sortable-item` component. 

Not a critical change, rather an improvement for test ergonomics in consuming applications, by following a widely adopted convention around testing with page objects.