### PR TITLE
publicize supported ember versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Ember Observer Score](http://emberobserver.com/badges/ember-sortable.svg)](http://emberobserver.com/addons/ember-sortable)
 [![Build Status](https://travis-ci.org/jgwhite/ember-sortable.svg?branch=master)](https://travis-ci.org/jgwhite/ember-sortable)
 [![Code Climate](https://codeclimate.com/github/jgwhite/ember-sortable/badges/gpa.svg)](https://codeclimate.com/github/jgwhite/ember-sortable)
+![Ember Version](https://embadge.io/v1/badge.svg?start=1.13.0)
 
 Sortable UI primitives for Ember.
 


### PR DESCRIPTION
Going by your ember-try testing on Travis, this is your minimum supported ember version. Is it correct, and do you want a badge for it?