### PR TITLE
remove unused ember-new-computed polyfill

### DIFF
--- a/addon/components/sortable-group.js
+++ b/addon/components/sortable-group.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import layout from '../templates/components/sortable-group';
-import computed from 'ember-new-computed';
+import computed from 'ember-computed';
 import {invokeAction} from 'ember-invoke-action';
 
 const { A, Component, get, set, run } = Ember;

--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import computed from 'ember-new-computed';
+import computed from 'ember-computed';
 import {invokeAction} from 'ember-invoke-action';
 import {throttle} from 'ember-runloop';
 

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.0.10",
-    "ember-invoke-action": "^1.4.0",
-    "ember-new-computed": "^1.0.2"
+    "ember-invoke-action": "^1.4.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
As a result of #127, it appears you do not need this polyfill anymore, as it targets ember versions prior to 1.12.0-beta.1.