### PR TITLE
Prevent touch-actions on element or handle using css

### DIFF
--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -269,6 +269,11 @@ export default Mixin.create({
     // scheduled to prevent deprecation warning:
     // "never change properties on components, services or models during didInsertElement because it causes significant performance degradation"
     run.schedule("afterRender", this, "_tellGroup", "registerItem", this);
+
+    // Instead of using `event.preventDefault()` in the 'primeDrag' event,
+    // (doesn't work in Chrome 56), we set touch-action: none as a workaround.
+    let element = this.get('handle') ? this.$(this.get('handle')) : this.$();
+    element.css({ 'touch-action': 'none' });
   },
 
   willDestroyElement() {
@@ -350,9 +355,6 @@ export default Mixin.create({
     if (handle && !$(event.target).closest(handle).length) {
       return;
     }
-
-    event.preventDefault();
-    event.stopPropagation();
 
     this._startDragListener = event => this._startDrag(event);
 


### PR DESCRIPTION
closes #130
- chrome 56 breaks the sortable-item touch events by setting them to passive by default. Because of this, we need to set ‘touch-action: false’ on a handle if it exists, or the entire element if it doesn’t

I'm also going to cherry-pick this commit onto the new branch, `1.x` that I created, and release a new version under 1.9.2 (because of the recently introduced breaking changes).