### PR TITLE
Dramatically increase performance by reducing relayout

### DIFF
--- a/addon/utils/slot.js
+++ b/addon/utils/slot.js
@@ -153,7 +153,7 @@ export default class Slot {
 
     if (node.isDestroyed || node.isDestroying) { return; }
 
-    node.$().css({ width: '', height: '', transform: '' }).height();
+    node.$().css({ width: '', height: '', transform: '' });
   }
 
   /**
@@ -164,7 +164,7 @@ export default class Slot {
 
     if (node.isDestroyed || node.isDestroying) { return; }
 
-    node.$().css('transition', 'none').height();
+    node.$().css('transition', 'none');
   }
 
   thaw() {
@@ -172,7 +172,7 @@ export default class Slot {
 
     if (node.isDestroyed || node.isDestroying) { return; }
 
-    node.$().css('transition', '').height();
+    node.$().css('transition', '');
   }
 
   /**


### PR DESCRIPTION
The combination of calling `css` and then `height` as in `node.$().css(...).height()` was causing a recalculate styles -> relayout for **each** slot. In my app, this increased performance of the `clear` function by approximately 1000x (1300ms -> 1.3ms). Granted, my app has a bit over 200 draggable elements, so the difference is more pronounced. In more normal apps, the change should still be noticeable.