### PR TITLE
Fix when surrounded by ember link-to

### DIFF
--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -673,7 +673,11 @@ export default Mixin.create({
    * @private
    */
   _preventClick(element) {
-    $(element).one('click', function(e){ e.stopImmediatePropagation(); } );
+    $(element).one('click', function(e){ 
+      e.stopPropagation();
+      e.preventDefault();
+      e.stopImmediatePropagation();
+    } );
   },
 
   /**


### PR DESCRIPTION
Somehow we needed this when our item was an Ember #link-to.
Without this we couldn't get the sorting to work.