### PR TITLE
Add distance attribute, for when sorting should start

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,16 @@ To change this property, define `spacing` on `sortable-item` (default is `0`):
 {{#sortable-item tagName="li" group=group spacing=15}}
 ```
 
+### Changing the drag tolerance
+
+`distance` attribute changes the tolerance, in pixels, for when sorting should start.
+If specified, sorting will not start until after mouse is dragged beyond distance.
+Can be used to allow for clicks on elements within a handle.
+
+```hbs
+{{#sortable-item group=group distance=30}}
+```
+
 ### CSS, Animation
 
 Sortable items can be in one of three states: default, dragging, dropping.

--- a/addon/helpers/drag.js
+++ b/addon/helpers/drag.js
@@ -54,6 +54,8 @@ export function drag(app, mode, itemSelector, offsetFn, callbacks = {}) {
     let itemElement = item.get(0);
     let rect = itemElement.getBoundingClientRect();
     let scale = itemElement.clientHeight / (rect.bottom - rect.top);
+    let halfwayX = itemOffset.left + (offset.dx * scale) / 2;
+    let halfwayY = itemOffset.top + (offset.dy * scale) / 2;
     let targetX = itemOffset.left + offset.dx * scale;
     let targetY = itemOffset.top + offset.dy * scale;
 
@@ -75,6 +77,11 @@ export function drag(app, mode, itemSelector, offsetFn, callbacks = {}) {
     if (callbacks.dragmove) {
       andThen(callbacks.dragmove);
     }
+
+    triggerEvent(app, item, move, {
+      pageX: halfwayX,
+      pageY: halfwayY
+    });
 
     triggerEvent(app, item, move, {
       pageX: targetX,

--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -7,7 +7,7 @@ import scrollParent from '../system/scroll-parent';
 import ScrollContainer from '../system/scroll-container';
 import {getX, getY, getBorderSpacing} from '../system/utils';
 
-const { Mixin, $, run } = Ember;
+const { Mixin, $, run, run: { bind } } = Ember;
 const { Promise } = Ember.RSVP;
 
 /**
@@ -50,6 +50,18 @@ export default Mixin.create({
    * @default null
    */
   handle: null,
+
+  /**
+   * Tolerance, in pixels, for when sorting should start.
+   * If specified, sorting will not start until after mouse
+   * is dragged beyond distance. Can be used to allow for clicks
+   * on elements within a handle.
+   *
+   * @property distance
+   * @type Integer
+   * @default 0
+   */
+  distance: 0,
 
   /**
    * True if the item is currently being dragged.
@@ -349,21 +361,40 @@ export default Mixin.create({
    * @param {Event} event JS Event object
    * @private
    */
-  _primeDrag(event) {
+  _primeDrag(startEvent) {
     let handle = this.get('handle');
 
-    if (handle && !$(event.target).closest(handle).length) {
+    if (handle && !$(startEvent.target).closest(handle).length) {
       return;
     }
 
-    this._startDragListener = event => this._startDrag(event);
+    this._prepareDragListener = bind(this, this._prepareDrag, startEvent);
 
     this._cancelStartDragListener = () => {
-      $(window).off('mousemove touchmove', this._startDragListener);
+      $(window).off('mousemove touchmove', this._prepareDragListener);
     };
 
-    $(window).one('mousemove touchmove', this._startDragListener);
+    $(window).on('mousemove touchmove', this._prepareDragListener);
     $(window).one('click mouseup touchend', this._cancelStartDragListener);
+  },
+
+  /**
+   * Prepares for the drag event
+   *
+   * @method _prepareDrag
+   * @param {Event} event JS Event object
+   * @param {Event} event JS Event object
+   * @private
+   */
+  _prepareDrag(startEvent, event) {
+    let distance = this.get('distance');
+    let dx = Math.abs(getX(startEvent) - getX(event));
+    let dy = Math.abs(getY(startEvent) - getY(event));
+
+    if (distance <= dx || distance <= dy) {
+      $(window).off('mousemove touchmove', this._prepareDragListener);
+      this._startDrag(startEvent);
+    }
   },
 
   /**

--- a/tests/acceptance/smoke-test.js
+++ b/tests/acceptance/smoke-test.js
@@ -101,6 +101,23 @@ test('reordering with mouse events', function(assert) {
     assert.equal(tableContents(), 'Dos Tres Uno Cuatro Cinco');
     assert.equal(scrollableContents(), 'Dos Tres Uno Cuatro Cinco');
   });
+
+  reorder(
+    'mouse',
+    '.vertical-distance-demo li',
+    ':contains("Tres")',
+    ':contains("Dos")',
+    ':contains("Uno")',
+    ':contains("Cuatro")',
+    ':contains("Cinco")'
+  );
+
+  andThen(() => {
+    assert.equal(verticalContents(), 'Tres Dos Uno Cuatro Cinco');
+    assert.equal(horizontalContents(), 'Tres Dos Uno Cuatro Cinco');
+    assert.equal(tableContents(), 'Tres Dos Uno Cuatro Cinco');
+    assert.equal(scrollableContents(), 'Tres Dos Uno Cuatro Cinco');
+  });
 });
 
 test('reordering with touch events', function(assert) {
@@ -162,6 +179,23 @@ test('reordering with touch events', function(assert) {
     assert.equal(horizontalContents(), 'Uno Dos Tres Cuatro Cinco');
     assert.equal(tableContents(), 'Uno Dos Tres Cuatro Cinco');
     assert.equal(scrollableContents(), 'Uno Dos Tres Cuatro Cinco');
+  });
+
+  reorder(
+    'touch',
+    '.vertical-distance-demo li',
+    ':contains("Tres")',
+    ':contains("Dos")',
+    ':contains("Uno")',
+    ':contains("Cuatro")',
+    ':contains("Cinco")'
+  );
+
+  andThen(() => {
+    assert.equal(verticalContents(), 'Tres Dos Uno Cuatro Cinco');
+    assert.equal(horizontalContents(), 'Tres Dos Uno Cuatro Cinco');
+    assert.equal(tableContents(), 'Tres Dos Uno Cuatro Cinco');
+    assert.equal(scrollableContents(), 'Tres Dos Uno Cuatro Cinco');
   });
 });
 

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -67,7 +67,7 @@
   color: pink;
 }
 
-.vertical-spacing-demo .sortable-item {
+.vertical-spacing-demo .sortable-item, .vertical-distance-demo .sortable-item {
   display: block;
   position: relative;
   background: #58D3F7;
@@ -77,7 +77,7 @@
   text-align: center;
 }
 
-.vertical-spacing-demo .sortable-item.is-dragging {
+.vertical-spacing-demo .sortable-item.is-dragging, .vertical-distance-demo .sortable-item.is-dragging {
   background: #A9E2F3;
 }
 

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -68,11 +68,11 @@
     </section>
 
     <section class="vertical-distance-demo">
-      <h3>Vertical with distance set to 30</h3>
+      <h3>Vertical with distance set to 15</h3>
 
       {{#sortable-group tagName="ol" onChange="update" as |group|}}
         {{#each model.items as |item|}}
-          {{#sortable-item tagName="li" model=item group=group distance=30}}
+          {{#sortable-item tagName="li" model=item group=group distance=15}}
             {{item}}
             <span class="handle" data-item="{{item}}">
             </span>

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -67,7 +67,7 @@
       {{/sortable-group}}
     </section>
 
-    <section class="vertical-spacing-demo">
+    <section class="vertical-distance-demo">
       <h3>Vertical with distance set to 15</h3>
 
       {{#sortable-group tagName="ol" onChange="update" as |group|}}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -67,7 +67,7 @@
       {{/sortable-group}}
     </section>
 
-    <section class="vertical-distance-demo">
+    <section class="vertical-spacing-demo">
       <h3>Vertical with distance set to 15</h3>
 
       {{#sortable-group tagName="ol" onChange="update" as |group|}}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -67,6 +67,20 @@
       {{/sortable-group}}
     </section>
 
+    <section class="vertical-distance-demo">
+      <h3>Vertical with distance set to 30</h3>
+
+      {{#sortable-group tagName="ol" onChange="update" as |group|}}
+        {{#each model.items as |item|}}
+          {{#sortable-item tagName="li" model=item group=group distance=30}}
+            {{item}}
+            <span class="handle" data-item="{{item}}">
+            </span>
+          {{/sortable-item}}
+        {{/each}}
+      {{/sortable-group}}
+    </section>
+
     <section class="scrollable-demo">
       <h3>Scrollable</h3>
 

--- a/tests/integration/components/sortable-group-test.js
+++ b/tests/integration/components/sortable-group-test.js
@@ -1,0 +1,40 @@
+import Ember from 'ember';
+import $ from 'jquery';
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+const { run } = Ember;
+
+moduleForComponent('sortable-group', 'Integration | Component | sortable group', {
+  integration: true
+});
+
+test('distance attribute prevents the drag before the specified value', function(assert) {
+  this.render(hbs`
+    {{#sortable-group as |group|}}
+      {{#sortable-item distance=15 model=1 group=group id="dummy-sortable-item"}}
+        {{item}}
+      {{/sortable-item}}
+    {{/sortable-group}}
+  `);
+
+  let item = $('#dummy-sortable-item');
+  let itemOffset = item.offset();
+
+  triggerEvent(item, 'mousedown', { pageX: itemOffset.left, pageY: itemOffset.top, which: 1 });
+  triggerEvent(item, 'mousemove', { pageX: itemOffset.left, pageY: itemOffset.top, which: 1 });
+  triggerEvent(item, 'mousemove', { pageX: itemOffset.left, pageY: itemOffset.top + 5, which: 1 });
+
+  assert.notOk(item.hasClass('is-dragging'), 'does not start dragging if the drag distance is less than the passed one');
+
+  triggerEvent(item, 'mousemove', { pageX: itemOffset.left, pageY: itemOffset.top + 20, which: 1 });
+
+  assert.ok(item.hasClass('is-dragging'), 'starts dragging if the drag distance is more than the passed one');
+});
+
+function triggerEvent(el, type, props) {
+  run(() => {
+    let event = $.Event(type, props);
+    $(el).trigger(event);
+  });
+}


### PR DESCRIPTION
I took a different approach from the existing PR. With this PR, the drag functionality is not registered until the node is dragged more than the passed distance.

Let me know if you have any comments.