### PR TITLE
make `_scrollOnEdges()` get `itemContainer` height dinamically

### DIFF
--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -405,7 +405,9 @@ export default Mixin.create({
     let scrollContainer = new ScrollContainer(scrollParent($element)[0]);
     let itemContainer = {
       width: $element.width(),
-      height: $element.height(),
+      get height() {
+        return $element.height();
+      },
       get left() {
         return $element.offset().left;
       },


### PR DESCRIPTION
This "fix" is kind of related with the autoscroll feature that was added on `1.8.3`. If the dragged element height is higher than its container, the autoscroll starts moving automatically. This change does not fix that, but allows that overriding element's height (by a css class for example) gets correctly calculated. 

Please let me know if I was clear enough or if you guys need some demo.