### PR TITLE
Cleanup listener registration

### DIFF
--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -8,9 +8,9 @@ import { throttle } from 'ember-runloop';
 const { Mixin, $, run } = Ember;
 const { Promise } = Ember.RSVP;
 
-const dragActions = 'mousemove touchmove';
-const elementClickAction = 'click';
-const endActions = 'click mouseup touchend';
+const dragActions = 'mousemove.emberSortable touchmove.emberSortable';
+const elementClickAction = 'click.emberSortable';
+const endActions = 'click.emberSortable mouseup.emberSortable touchend.emberSortable';
 
 export default Mixin.create({
   classNames: ['sortable-item'],

--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -8,6 +8,10 @@ import { throttle } from 'ember-runloop';
 const { Mixin, $, run } = Ember;
 const { Promise } = Ember.RSVP;
 
+const dragActions = 'mousemove touchmove';
+const elementClickAction = 'click';
+const endActions = 'click mouseup touchend';
+
 export default Mixin.create({
   classNames: ['sortable-item'],
   classNameBindings: ['isDragging', 'isDropping'],
@@ -253,8 +257,8 @@ export default Mixin.create({
     run.schedule("afterRender", this, "_tellGroup", "deregisterItem", this);
 
     // remove event listeners that may still be attached
-    $(window).off('mousemove touchmove', this._startDragListener);
-    $(window).off('click mouseup touchend', this._cancelStartDragListener);
+    $(window).off(dragActions, this._startDragListener);
+    $(window).off(endActions, this._cancelStartDragListener);
   },
 
   /**
@@ -330,11 +334,11 @@ export default Mixin.create({
     this._prepareDragListener = run.bind(this, this._prepareDrag, startEvent);
 
     this._cancelStartDragListener = () => {
-      $(window).off('mousemove touchmove', this._prepareDragListener);
+      $(window).off(dragActions, this._prepareDragListener);
     };
 
-    $(window).on('mousemove touchmove', this._prepareDragListener);
-    $(window).one('click mouseup touchend', this._cancelStartDragListener);
+    $(window).on(dragActions, this._prepareDragListener);
+    $(window).one(endActions, this._cancelStartDragListener);
   },
 
   /**
@@ -351,7 +355,7 @@ export default Mixin.create({
     let dy = Math.abs(getY(startEvent) - getY(event));
 
     if (distance <= dx || distance <= dy) {
-      $(window).off('mousemove touchmove', this._prepareDragListener);
+      $(window).off(dragActions, this._prepareDragListener);
       this._startDrag(startEvent);
     }
   },
@@ -371,15 +375,15 @@ export default Mixin.create({
 
     let drop = () => {
       $(window)
-        .off('mousemove touchmove', dragThrottled)
-        .off('click mouseup touchend', drop);
+        .off(dragActions, dragThrottled)
+        .off(endActions, drop);
 
       this._drop();
     };
 
     $(window)
-      .on('mousemove touchmove', dragThrottled)
-      .on('click mouseup touchend', drop);
+      .on(dragActions, dragThrottled)
+      .on(endActions, drop);
 
     this._tellGroup('prepare');
     this.set('isDragging', true);
@@ -608,7 +612,7 @@ export default Mixin.create({
     @private
   */
   _preventClick(element) {
-    $(element).one('click', function(e){ e.stopImmediatePropagation(); } );
+    $(element).one(elementClickAction, function(e){ e.stopImmediatePropagation(); } );
   },
 
   /**


### PR DESCRIPTION
These are a couple of small changes to try to reduce the likelihood of typos and omissions during the event registration and teardown operations. I've also added [namespaces](http://api.jquery.com/on/) to events so that while debugging orphaned `window` events, developers can see an `emberSortable` namespace reported to identify their source.