### PR TITLE
Disable isDragging when element is destroyed

### DIFF
--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -259,6 +259,8 @@ export default Mixin.create({
     // remove event listeners that may still be attached
     $(window).off(dragActions, this._startDragListener);
     $(window).off(endActions, this._cancelStartDragListener);
+    this.set('isDragging', false);
+    this.set('isDropping', false);
   },
 
   /**

--- a/tests/unit/components/sortable-item-mixin-test.js
+++ b/tests/unit/components/sortable-item-mixin-test.js
@@ -58,6 +58,19 @@ test('isAnimated', function(assert) {
   assert.equal(subject.get('isAnimated'), false);
 });
 
+test('isDragging is disabled when destroyed', function(assert) {
+  assert.expect(3);
+
+  run(() => {
+    subject.set('model', MockModel);
+    assert.equal(subject.get('isDragging'), false);
+    subject._startDrag(MockEvent);
+    assert.equal(subject.get('isDragging'), true);
+    subject.destroy();
+    assert.equal(subject.get('isDragging'), false);
+  });
+});
+
 test('transitionDuration', function(assert) {
   subject.$().css({ transition: 'all .25s' });
   assert.equal(subject.get('transitionDuration'), 250);


### PR DESCRIPTION
While debugging an issue in an application, we came across a case where the act of dragging an element caused re-renders and actively-dragging-element destruction.

In this scenario, ember-sortable would endlessly scroll the page to the top of the screen because the `isDragging` flag remained true (once dragging began) even after the element was destroyed. This occurred because the `_scrollOnEdges` method uses `requestAnimationFrame` to recursively call itself while dragging. If the element is destroyed and isDragging is forever true, these recursive calls will never end.