### PR TITLE
Alias sortable direction to group

### DIFF
--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -234,6 +234,13 @@ export default Mixin.create({
   }).volatile(),
 
   /**
+    @private
+    Allows host instance to use the `group` property for something else with
+    minimal overriding.
+  */
+  _direction: computed.readOnly('group.direction'),
+
+  /**
     @method didInsertElement
   */
   didInsertElement() {
@@ -402,7 +409,7 @@ export default Mixin.create({
   maxScrollSpeed: 20,
 
   _scrollOnEdges(drag) {
-    let groupDirection = this.get('group.direction');
+    let groupDirection = this.get('_direction');
     let $element = this.$();
     let scrollContainer = new ScrollContainer(scrollParent($element)[0]);
     let itemContainer = {
@@ -491,7 +498,7 @@ export default Mixin.create({
     @private
   */
   _makeDragHandler(startEvent) {
-    const groupDirection = this.get('group.direction');
+    const groupDirection = this.get('_direction');
     let dragOrigin;
     let elementOrigin;
     let scrollOrigin;
@@ -555,7 +562,7 @@ export default Mixin.create({
   _applyPosition() {
     if (!this.element || !this.$()) { return; }
 
-    const groupDirection = this.get('group.direction');
+    const groupDirection = this.get('_direction');
 
     if (groupDirection === 'x') {
       let x = this.get('x');
@@ -581,7 +588,7 @@ export default Mixin.create({
   */
   _drag(dimension) {
     let updateInterval = this.get('updateInterval');
-    const groupDirection = this.get('group.direction');
+    const groupDirection = this.get('_direction');
 
     if (groupDirection === 'x') {
       this.set('x', dimension);


### PR DESCRIPTION
We are using this addon in an application where `group` is already a thing in many places.
Therefore we would like to use a different name for that variable.
With this change we only have to override `_direction` and `_tellGroup` instead of having to copy complete methods.

Let me know if this is desired or if you know a better way!