### PR TITLE
fix for issue with transforms being left after drop

### DIFF
--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -580,6 +580,9 @@ export default Mixin.create({
     @private
   */
   _drag(dimension) {
+    if(!this.get("isDragging")) {
+      return;
+    }
     let updateInterval = this.get('updateInterval');
     const groupDirection = this.get('group.direction');
 


### PR DESCRIPTION
fixes #132. 

`_drag` was being invoked after `reset` was called on the item, and after a drop.