### PR TITLE
Add tabindex attribute binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,19 @@ No data is mutated by `sortable-group` or `sortable-item`. In the spirit of “d
 
 Each item takes a `model` property. This should be fairly self-explanatory but it’s important to note that it doesn’t do anything with this object besides keeping a reference for later use in `onChange`.
 
+### Accessibility
+
+`sortable-item`s can receive a `tabindex` which allows them to be focused.  Use this to enable keyboard sorting for accessibility.
+
+```hbs
+{{#each myItems as |item idx| }}
+  {{#sortable-item tabindex=0 keyUp=(action 'keyUp' idx) tagName="li" model=item group=group handle=".handle"}}
+    {{item.name}}
+    <span class="handle">&varr;</span>
+  {{/sortable-item}}
+{{/each}}
+```
+
 ## Testing
 
 `ember-sortable` exposes some acceptance test helpers:

--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -16,7 +16,7 @@ export default Mixin.create({
   classNames: ['sortable-item'],
   classNameBindings: ['isDragging', 'isDropping'],
 
-  attributeBindings: ['data-test-selector'],
+  attributeBindings: ['data-test-selector', 'tabindex'],
 
   /**
     Group to which the item belongs.

--- a/tests/integration/components/sortable-group-test.js
+++ b/tests/integration/components/sortable-group-test.js
@@ -32,6 +32,20 @@ test('distance attribute prevents the drag before the specified value', function
   assert.ok(item.hasClass('is-dragging'), 'starts dragging if the drag distance is more than the passed one');
 });
 
+test('sortable-items have tabindexes for accessibility', function (assert) {
+  this.render(hbs`
+    {{#sortable-group as |group|}}
+      {{#sortable-item tabindex=0 model=1 id="dummy-sortable-item"}}
+        sort me
+      {{/sortable-item}}
+    {{/sortable-group}}
+  `);
+
+  let item = this.$('#dummy-sortable-item');
+
+  assert.equal(item.attr('tabindex'), 0, 'sortable-items have tabindexes');
+});
+
 function triggerEvent(el, type, props) {
   run(() => {
     let event = $.Event(type, props);


### PR DESCRIPTION
This enables simple keyboard-based accessible sorting via  a `keyUp` handler.

For example:

```hbs
  {{#each myItems as |item idx| }}
    {{#sortable-item tabindex=0 keyUp=(action 'keyUp' idx) model=item }}
      {{item.name}}
    {{/sortable-item}}
  {{/each}}
```

```js
actions: {
  keyUp(index, evt) {
    switch(evt.key) {
      case "ArrowDown":
        // move item at `index` back one
        break;
      case "ArrowUp":
        // move item at `index` forward one
        break;
      default:
        return;
    }
  }
}
```