### PR TITLE
Remove jquery event listener from component element

### DIFF
--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -611,7 +611,7 @@ export default Mixin.create({
   _drop() {
     if (!this.element || !this.$()) { return; }
 
-    this._preventClick(this.element);
+    this._preventClick();
 
     this.set('isDragging', false);
     this.set('isDropping', true);
@@ -626,8 +626,8 @@ export default Mixin.create({
     @method _preventClick
     @private
   */
-  _preventClick(element) {
-    $(element).one(elementClickAction, this._preventClickHandler);
+  _preventClick() {
+    $(this.element).one(elementClickAction, this._preventClickHandler);
   },
 
   /**

--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -266,6 +266,7 @@ export default Mixin.create({
     // remove event listeners that may still be attached
     $(window).off(dragActions, this._startDragListener);
     $(window).off(endActions, this._cancelStartDragListener);
+    $(this.element).off(elementClickAction, this._preventClickHandler);
     this.set('isDragging', false);
     this.set('isDropping', false);
   },
@@ -626,11 +627,17 @@ export default Mixin.create({
     @private
   */
   _preventClick(element) {
-    $(element).one(elementClickAction, function(e){ 
-      e.stopPropagation();
-      e.preventDefault();
-      e.stopImmediatePropagation();
-    } );
+    $(element).one(elementClickAction, this._preventClickHandler);
+  },
+
+  /**
+    @method _preventClickHandler
+    @private
+  */
+  _preventClickHandler(e) {
+    e.stopPropagation();
+    e.preventDefault();
+    e.stopImmediatePropagation();
   },
 
   /**


### PR DESCRIPTION
I am working removing memory leaks across test runs in a very large ember app. I noticed that jquery seems to maintain a reference to the element here because of the event listener. I thought this was a bit strange as I expected the listener would be eligible for garbage collection once the element is removed from the dom. However, I believe the issue is that jquery maintains a cache of elements passed to its constructor and does not know to update its internal cache if the element is removed using native apis or some other non-jquery technique. The result is when when the test run is complete, there is an application container instance that cannot be garbage collected. This should not affect any logic or functionality. just notifies jquery that the listener should be removed when the component is destroyed.  