### PR TITLE
Fix deprecation warnings for targetObject

### DIFF
--- a/tests/unit/components/sortable-group-test.js
+++ b/tests/unit/components/sortable-group-test.js
@@ -241,14 +241,14 @@ test('commit without specified group model', function(assert) {
     model: 'foo'
   }];
 
-  let targetObject = EmberObject.create({
+  let target = EmberObject.create({
     reorder(newOrder) {
       this.newOrder = newOrder;
     }
   });
   let component = this.subject({
     items,
-    targetObject,
+    target,
     onChange: 'reorder'
   });
 
@@ -256,7 +256,7 @@ test('commit without specified group model', function(assert) {
     component.commit();
   });
 
-  assert.deepEqual(targetObject.newOrder, ['foo', 'bar', 'baz'],
+  assert.deepEqual(target.newOrder, ['foo', 'bar', 'baz'],
     'expected target to receive models in order');
 });
 
@@ -275,16 +275,16 @@ test('commit with specified group model', function(assert) {
   let model = {
     items: items
   };
-  let targetObject = EmberObject.create({
+  let target = EmberObject.create({
     reorder(model, newOrder) {
       model.newOrder = newOrder;
-      targetObject.newModel = model;
+      target.newModel = model;
     }
   });
   let component = this.subject({
     model,
     items,
-    targetObject,
+    target,
     onChange: 'reorder'
   });
 
@@ -292,7 +292,7 @@ test('commit with specified group model', function(assert) {
     component.commit();
   });
 
-  assert.deepEqual(targetObject.newModel.newOrder, ['foo', 'bar', 'baz'],
+  assert.deepEqual(target.newModel.newOrder, ['foo', 'bar', 'baz'],
     'expected target to receive models in order');
 });
 
@@ -308,17 +308,17 @@ test('commit with missmatched group model', function(assert) {
     model: 'foo'
   }];
   let model = null;
-  let targetObject = EmberObject.create({
+  let target = EmberObject.create({
     reorder(model, newOrder) {
       if (typeof newOrder !== 'undefined') {
-        targetObject.correctActionFired = true;
+        target.correctActionFired = true;
       }
     }
   });
   let component = this.subject({
     model,
     items,
-    targetObject,
+    target,
     onChange: 'reorder'
   });
 
@@ -326,7 +326,7 @@ test('commit with missmatched group model', function(assert) {
     component.commit();
   });
 
-  assert.equal(targetObject.correctActionFired, true,
+  assert.equal(target.correctActionFired, true,
     'expected reorder() to receive two params');
 });
 
@@ -345,7 +345,7 @@ test('draggedModel', function(assert) {
     model: 'Three'
   }];
 
-  let targetObject = {
+  let target = {
     action(models, draggedModel) {
       assert.equal(draggedModel, 'Two');
     }
@@ -353,7 +353,7 @@ test('draggedModel', function(assert) {
 
   let component = this.subject({
     items,
-    targetObject,
+    target,
     onChange: 'action'
   });
 

--- a/tests/unit/components/sortable-item-mixin-test.js
+++ b/tests/unit/components/sortable-item-mixin-test.js
@@ -165,7 +165,7 @@ test('deregisters itself when removed', function(assert) {
 test('dragStart fires an action if provided', function(assert) {
   assert.expect(1);
 
-  const targetObject = {
+  const target = {
     action(passedModel) {
       assert.equal(passedModel, MockModel);
     }
@@ -173,7 +173,7 @@ test('dragStart fires an action if provided', function(assert) {
 
   run(() => {
     subject.set('model', MockModel);
-    subject.set('targetObject', targetObject);
+    subject.set('target', target);
     subject.set('onDragStart', 'action');
     subject._startDrag(MockEvent);
   });
@@ -182,7 +182,7 @@ test('dragStart fires an action if provided', function(assert) {
 test('dragStop fires an action if provided', function(assert) {
   assert.expect(1);
 
-  const targetObject = {
+  const target = {
     action(passedModel) {
       assert.equal(passedModel, MockModel);
     }
@@ -190,7 +190,7 @@ test('dragStop fires an action if provided', function(assert) {
 
   run(() => {
     subject.set('model', MockModel);
-    subject.set('targetObject', targetObject);
+    subject.set('target', target);
     subject.set('onDragStop', 'action');
     subject._complete();
   });


### PR DESCRIPTION
`targetObject` is deprecated in favor of `target` ([see more](https://www.emberjs.com/deprecations/v2.x/#toc_code-targetobject-code)). Fixes ##167

This fixes tests that used `targetObject`. They pass 100%